### PR TITLE
fix: health_check.path for https protocol, add health_check.matcher support

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -294,6 +294,12 @@ variable "health_check_timeout" {
   description = "The amount of time, in seconds, during which no response means a failed health check"
 }
 
+variable "health_check_matcher" {
+  type        = string
+  default     = null
+  description = "The HTTP or gRPC codes to use when checking for a successful response from a target, values can be comma-separated individual values or a range of values"
+}
+
 variable "stickiness_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what

- Added support for the `health_check.matcher`, enabling customization of HTTP or gRPC matcher codes for target group health checks.
- Updated health check path logic to support the HTTPS protocol.

## why

- Allows users to specify custom matcher codes for health checks, enhancing flexibility and compatibility with various backend requirements.
- Fixes an issue where the health check path could be incorrectly set for the HTTPS protocol.

## references

- Open issue: https://github.com/cloudposse/terraform-aws-nlb/issues/76
- Terraform docs: https://registry.terraform.io/providers/-/aws/5.99.1/docs/resources/lb_target_group#health_check
